### PR TITLE
fix(mcp): strip 'type' from args before queueing generate jobs

### DIFF
--- a/src/mcp_server.cpp
+++ b/src/mcp_server.cpp
@@ -356,6 +356,7 @@ json McpServer::tool_generate(const json& args) {
         if (args.contains("image_base64") && !args.contains("init_image_base64")) {
             job_args["init_image_base64"] = args["image_base64"];
         }
+        job_args.erase("type");
         try {
             std::string job_id = queue_manager_.add_job(GenerationType::Upscale, job_args);
             json result = {{"job_id", job_id}, {"status", "pending"}, {"message", "Upscale job queued"}};
@@ -392,8 +393,10 @@ json McpServer::tool_generate(const json& args) {
         return make_tool_result("Unknown generation type: " + type + ". Use: txt2img, img2img, video, upscale", true);
     }
 
+    json job_args = args;
+    job_args.erase("type");
     try {
-        std::string job_id = queue_manager_.add_job(gen_type, args);
+        std::string job_id = queue_manager_.add_job(gen_type, job_args);
         json result = {{"job_id", job_id}, {"status", "pending"}, {"message", message}};
         return make_tool_result(result.dump());
     } catch (const std::exception& e) {


### PR DESCRIPTION
## What

`McpServer::tool_generate` now erases the `type` key from job args before calling `queue_manager_.add_job` in both code paths (upscale, and txt2img/img2img/video).

## Why

`type` is a dispatch/routing parameter for the consolidated MCP `generate` tool — it selects which `GenerationType` to queue. It is not a generation parameter. Previously the raw args were forwarded as-is, leaking `type` into the queued job's args. See the following error.
```
Unknown field(s) in /txt2img body: type. Check the spelling against the OpenAPI schema at /openapi.json.

- Status: failed
- Completed At: 2026-06-23T13:17:52Z
- Created At: 2026-06-23T13:17:52Z
- Error: Unknown field(s) in /txt2img body: type. Check the spelling against the OpenAPI schema at /openapi.json.
- Job Id: 6e7bb7e0-d0b9-498c-8fb9-cdf18b549625
- Model Settings: Model Architecture: SD3.x · Model Loaded: true
- Params: Prompt: A cute fluffy kitten sitting in a garden with flowers, soft lighting, high detail, realistic style, 8k resolution. · Type: txt2img
- Progress: Step: 0 · Total Steps: 0
- … 2 more fields
```

## Notes

- Upscale path: erase on the existing `job_args` copy.
- Other types: introduce a `job_args` copy (was passing `args` directly) and erase before queueing.