### PR TITLE
feat(mcp): add 'image' tool to fetch generated images inline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,7 +172,7 @@ The MCP server at `POST /mcp` implements JSON-RPC 2.0 for Streamable HTTP transp
 - `generate(type, prompt, ...)` — Types: `txt2img`, `img2img`, `video`, `upscale`
 - `model(action, ...)` — Actions: `load`, `unload`, `list`
 - `job(action, ...)` — Actions: `status`, `cancel`, `delete` (soft-delete → recycle bin), `search` (filtered/paginated)
-- `image(job_id, [index])` — Returns a completed job's output(s) as inline MCP image content (base64) so the model can actually see the result, not just a URL. Capped at 4 images; `.mp4` outputs skipped (use the URL from `job status`).
+- `image(job_id, [index], [size])` — Returns a completed job's output(s) as inline MCP image content (base64 JPEG) so a vision-capable model can see the result, not just a URL. **Opt-in: only registered when `config.mcp.image_tool_enabled` is true.** Outputs are downscaled to `size` (longest side, default `mcp.image_default_max_dim`=768, clamped to `mcp.image_max_dim`=2048) and JPEG-re-encoded (`mcp.image_jpeg_quality`=85) to bound payload — an 8192px upscale comes back small. Capped at 4 images; non-decodable outputs (`.mp4`, webp) skipped (use the URL from `job status`). `/health` `features.mcp_image_tool` reports the toggle.
 
 **Resources (7):** sdcpp://health, sdcpp://memory, sdcpp://models, sdcpp://models/loaded, sdcpp://queue (last 10 items), sdcpp://queue/{job_id}, sdcpp://architectures
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,10 +168,11 @@ Events broadcast from `src/websocket_server.cpp`:
 
 The MCP server at `POST /mcp` implements JSON-RPC 2.0 for Streamable HTTP transport. It's compile-time optional via `SDCPP_MCP` (ON by default).
 
-**Tools (3 consolidated):**
+**Tools (4):**
 - `generate(type, prompt, ...)` — Types: `txt2img`, `img2img`, `video`, `upscale`
 - `model(action, ...)` — Actions: `load`, `unload`, `list`
 - `job(action, ...)` — Actions: `status`, `cancel`, `delete` (soft-delete → recycle bin), `search` (filtered/paginated)
+- `image(job_id, [index])` — Returns a completed job's output(s) as inline MCP image content (base64) so the model can actually see the result, not just a URL. Capped at 4 images; `.mp4` outputs skipped (use the URL from `job status`).
 
 **Resources (7):** sdcpp://health, sdcpp://memory, sdcpp://models, sdcpp://models/loaded, sdcpp://queue (last 10 items), sdcpp://queue/{job_id}, sdcpp://architectures
 

--- a/config.example.json
+++ b/config.example.json
@@ -56,5 +56,11 @@
         "password": "",
         "token_ttl_minutes": 1440,
         "allow_public_outputs": true
+    },
+    "mcp": {
+        "image_tool_enabled": false,
+        "image_default_max_dim": 768,
+        "image_max_dim": 2048,
+        "image_jpeg_quality": 85
     }
 }

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -123,6 +123,28 @@ struct AuthConfig {
     bool allow_public_outputs = true;
 };
 
+struct McpConfig {
+    // Gates the MCP `image` tool, which returns generated image bytes inline
+    // (base64) so a vision-capable model can actually see the result. OFF by
+    // default: the inline payload is only useful to multimodal clients and
+    // costs context tokens, so opting in is a deliberate choice.
+    bool image_tool_enabled = false;
+
+    // Default max output dimension (longest side, px) the `image` tool
+    // downscales to before JPEG-encoding when the caller omits `size`. Kept
+    // conservative so an 8192² upscale doesn't blow up the context by default.
+    // A context-rich operator can raise this; the model can still override
+    // per-call via the tool's `size` parameter, clamped to image_max_dim.
+    int image_default_max_dim = 768;
+
+    // Hard ceiling for the per-call `size` parameter. Caps how large a model
+    // can request regardless of intent, bounding worst-case payload size.
+    int image_max_dim = 2048;
+
+    // JPEG quality (1-100) used when re-encoding image-tool output.
+    int image_jpeg_quality = 85;
+};
+
 /**
  * Complete application configuration
  */
@@ -134,6 +156,7 @@ struct Config {
     AssistantConfig assistant;
     RecycleBinConfig recycle_bin;
     AuthConfig auth;
+    McpConfig mcp;
 
     // When true, jobs created via expand_prompt write outputs into
     // <output>/<group_id>/<job_id>/ instead of flat <output>/<job_id>/. Lets

--- a/include/mcp_server.hpp
+++ b/include/mcp_server.hpp
@@ -10,6 +10,7 @@ namespace sdcpp {
 class ModelManager;
 class QueueManager;
 class AuthManager;
+struct McpConfig;
 
 /**
  * MCP (Model Context Protocol) Server
@@ -20,7 +21,7 @@ class AuthManager;
 class McpServer {
 public:
     McpServer(httplib::Server& server, ModelManager& model_manager, QueueManager& queue_manager,
-              AuthManager& auth_manager);
+              AuthManager& auth_manager, const McpConfig& mcp_config);
 
     /** Register the POST /mcp endpoint on the HTTP server */
     void register_endpoint();
@@ -65,6 +66,7 @@ private:
     ModelManager& model_manager_;
     QueueManager& queue_manager_;
     AuthManager& auth_manager_;
+    const McpConfig& mcp_config_;
     std::string base_url_;  // Set per-request from Host header
 };
 

--- a/include/mcp_server.hpp
+++ b/include/mcp_server.hpp
@@ -41,6 +41,7 @@ private:
     nlohmann::json tool_generate(const nlohmann::json& args);
     nlohmann::json tool_model(const nlohmann::json& args);
     nlohmann::json tool_job(const nlohmann::json& args);
+    nlohmann::json tool_image(const nlohmann::json& args);
 
     // Resource implementations
     nlohmann::json resource_health();

--- a/include/queue_manager.hpp
+++ b/include/queue_manager.hpp
@@ -424,6 +424,9 @@ public:
     bool get_group_folders_enabled() const {
         return group_folders_enabled_.load(std::memory_order_relaxed);
     }
+    // Output directory that job output paths are relative to. Used by callers
+    // (e.g. MCP image tool) that need to read generated files off disk.
+    const std::string& output_dir() const { return output_dir_; }
 private:
     /**
      * Compose the per-job subpath under output_dir_. Returns "<group_id>/<job_id>"

--- a/include/request_handlers.hpp
+++ b/include/request_handlers.hpp
@@ -236,6 +236,7 @@ private:
     PathsConfig paths_config_;  // Snapshot of configured model/output paths (for WebDAV mapping)
     bool allow_public_outputs_ = true;          // auth.allow_public_outputs
     std::vector<std::string> trusted_proxies_;  // server.trusted_proxies (X-Forwarded-* whitelist)
+    bool mcp_image_tool_enabled_ = false;       // mcp.image_tool_enabled (surfaced in /health features)
     std::string output_dir_;
     std::string webui_dir_;
     std::string docs_dir_;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -166,6 +166,23 @@ void from_json(const nlohmann::json& j, RecycleBinConfig& c) {
     c.retention_minutes = j.value("retention_minutes", 10080);
 }
 
+// McpConfig JSON serialization
+void to_json(nlohmann::json& j, const McpConfig& c) {
+    j = nlohmann::json{
+        {"image_tool_enabled", c.image_tool_enabled},
+        {"image_default_max_dim", c.image_default_max_dim},
+        {"image_max_dim", c.image_max_dim},
+        {"image_jpeg_quality", c.image_jpeg_quality}
+    };
+}
+
+void from_json(const nlohmann::json& j, McpConfig& c) {
+    c.image_tool_enabled = j.value("image_tool_enabled", false);
+    c.image_default_max_dim = j.value("image_default_max_dim", 768);
+    c.image_max_dim = j.value("image_max_dim", 2048);
+    c.image_jpeg_quality = j.value("image_jpeg_quality", 85);
+}
+
 // Config JSON serialization
 void to_json(nlohmann::json& j, const Config& c) {
     j = nlohmann::json{
@@ -176,6 +193,7 @@ void to_json(nlohmann::json& j, const Config& c) {
         {"assistant", c.assistant},
         {"recycle_bin", c.recycle_bin},
         {"auth", c.auth},
+        {"mcp", c.mcp},
         {"output_group_folders", c.output_group_folders}
     };
 }
@@ -201,6 +219,9 @@ void from_json(const nlohmann::json& j, Config& c) {
     }
     if (j.contains("auth")) {
         c.auth = j["auth"].get<AuthConfig>();
+    }
+    if (j.contains("mcp")) {
+        c.mcp = j["mcp"].get<McpConfig>();
     }
     if (j.contains("output_group_folders")) {
         c.output_group_folders = j["output_group_folders"].get<bool>();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -415,7 +415,7 @@ int main(int argc, char* argv[]) {
         // Initialize MCP server (if enabled at build time)
 #ifdef SDCPP_MCP_ENABLED
         std::cout << "Initializing MCP server..." << std::endl;
-        sdcpp::McpServer mcp_server(server, model_manager, queue_manager, auth_manager);
+        sdcpp::McpServer mcp_server(server, model_manager, queue_manager, auth_manager, config.mcp);
         mcp_server.register_endpoint();
 #else
         std::cout << "MCP server disabled at build time" << std::endl;

--- a/src/mcp_server.cpp
+++ b/src/mcp_server.cpp
@@ -4,6 +4,10 @@
 #include "memory_utils.hpp"
 #include "auth_manager.hpp"
 #include "utils.hpp"
+#include "config.hpp"
+#include "stb_image.h"
+#include "stb_image_write.h"
+#include "stb_image_resize.h"
 
 #include <iostream>
 #include <fstream>
@@ -13,6 +17,8 @@
 #include <iterator>
 #include <cctype>
 #include <cstdint>
+#include <cstdlib>
+#include <algorithm>
 
 namespace sdcpp {
 
@@ -21,9 +27,9 @@ using json = nlohmann::json;
 // ─── Constructor ─────────────────────────────────────────────────────────────
 
 McpServer::McpServer(httplib::Server& server, ModelManager& model_manager, QueueManager& queue_manager,
-                     AuthManager& auth_manager)
+                     AuthManager& auth_manager, const McpConfig& mcp_config)
     : server_(server), model_manager_(model_manager), queue_manager_(queue_manager),
-      auth_manager_(auth_manager) {}
+      auth_manager_(auth_manager), mcp_config_(mcp_config) {}
 
 // ─── Endpoint Registration ───────────────────────────────────────────────────
 
@@ -322,19 +328,35 @@ json McpServer::handle_list_tools() {
         }}
     });
 
-    // 4. image — fetch generated image bytes for a completed job
-    tools.push_back({
-        {"name", "image"},
-        {"description", "Fetch the actual generated image(s) for a completed job as inline image content (not just a URL). Use this after 'generate' + 'job status' to let the model see the result. Returns image content blocks the model can view. Video (.mp4) outputs cannot be returned inline — use the URL from 'job status' instead."},
-        {"inputSchema", {
-            {"type", "object"},
-            {"required", json::array({"job_id"})},
-            {"properties", {
-                {"job_id", {{"type", "string"}, {"description", "Job UUID of a completed generation job"}}},
-                {"index", {{"type", "integer"}, {"description", "Zero-based index of a single output to fetch. Omit to fetch all outputs (capped at 4)."}}}
+    // 4. image — fetch generated image bytes for a completed job.
+    //    Gated behind config: the inline base64 payload is only useful to a
+    //    vision-capable client and costs context tokens, so it's opt-in.
+    if (mcp_config_.image_tool_enabled) {
+        tools.push_back({
+            {"name", "image"},
+            {"description",
+                "Fetch the actual generated image(s) for a completed job as inline image "
+                "content (not just a URL) so a vision-capable model can view the result. "
+                "Use after 'generate' + 'job status'. Images are downscaled to the 'size' "
+                "longest-side limit (default " + std::to_string(mcp_config_.image_default_max_dim) +
+                "px) and re-encoded as JPEG to bound payload size, so an 8192px upscale "
+                "won't flood the context. Video (.mp4) outputs cannot be returned inline — "
+                "use the URL from 'job status' instead."},
+            {"inputSchema", {
+                {"type", "object"},
+                {"required", json::array({"job_id"})},
+                {"properties", {
+                    {"job_id", {{"type", "string"}, {"description", "Job UUID of a completed generation job"}}},
+                    {"index", {{"type", "integer"}, {"description", "Zero-based index of a single output to fetch. Omit to fetch all outputs (capped at 4)."}}},
+                    {"size", {{"type", "integer"}, {"description",
+                        "Max longest-side dimension in pixels. The image is downscaled to fit "
+                        "(aspect preserved; never upscaled). Omit for the server default (" +
+                        std::to_string(mcp_config_.image_default_max_dim) + "px). Clamped to a max of " +
+                        std::to_string(mcp_config_.image_max_dim) + "px."}}}
+                }}
             }}
-        }}
-    });
+        });
+    }
 
     return {{"tools", tools}};
 }
@@ -352,7 +374,13 @@ json McpServer::handle_call_tool(const json& params) {
     if (name == "generate") return tool_generate(args);
     if (name == "model") return tool_model(args);
     if (name == "job") return tool_job(args);
-    if (name == "image") return tool_image(args);
+    if (name == "image") {
+        if (!mcp_config_.image_tool_enabled) {
+            return make_tool_result("The 'image' tool is disabled. Enable it via "
+                                    "config mcp.image_tool_enabled.", true);
+        }
+        return tool_image(args);
+    }
 
     return make_tool_result("Unknown tool: " + name, true);
 }
@@ -457,40 +485,68 @@ json McpServer::tool_image(const json& args) {
     bool truncated = selected.size() > kMaxImages;
     if (truncated) selected.resize(kMaxImages);
 
-    // Map file extension to MIME type. Only raster image types are returnable
-    // as MCP image content; video (.mp4) and unknown types are skipped.
-    auto mime_for = [](const std::string& path) -> std::string {
-        auto dot = path.find_last_of('.');
-        if (dot == std::string::npos) return "";
-        std::string ext = path.substr(dot + 1);
-        for (auto& c : ext) c = static_cast<char>(::tolower(c));
-        if (ext == "png") return "image/png";
-        if (ext == "jpg" || ext == "jpeg") return "image/jpeg";
-        if (ext == "webp") return "image/webp";
-        if (ext == "gif") return "image/gif";
-        return "";
+    // Resolve the longest-side limit: caller's `size`, else the server default,
+    // clamped to [1, image_max_dim] so a model can't request an unbounded image.
+    int max_dim = mcp_config_.image_default_max_dim;
+    if (args.contains("size") && args["size"].is_number_integer()) {
+        max_dim = args["size"].get<int>();
+    }
+    if (max_dim < 1) max_dim = 1;
+    if (max_dim > mcp_config_.image_max_dim) max_dim = mcp_config_.image_max_dim;
+
+    // Decode → (downscale to max_dim, aspect preserved, never upscale) → JPEG.
+    // This bounds payload size regardless of source resolution, so an 8192px
+    // upscale comes back as a small JPEG instead of a multi-MB base64 blob.
+    // Returns base64 JPEG, or "" with `err` set. Non-decodable outputs (video,
+    // webp — stb can't read those) fail here and are reported as skipped.
+    const int jpeg_quality = mcp_config_.image_jpeg_quality;
+    auto encode_jpeg = [max_dim, jpeg_quality](const std::string& path,
+                                               std::string& err) -> std::string {
+        int w, h, ch;
+        unsigned char* data = stbi_load(path.c_str(), &w, &h, &ch, 3);  // force RGB
+        if (!data) {
+            const char* reason = stbi_failure_reason();
+            err = std::string("decode failed") + (reason ? std::string(": ") + reason : "");
+            return "";
+        }
+        bool resized = false;
+        if (w > max_dim || h > max_dim) {
+            float scale = std::min(static_cast<float>(max_dim) / w,
+                                   static_cast<float>(max_dim) / h);
+            int nw = std::max(1, static_cast<int>(w * scale));
+            int nh = std::max(1, static_cast<int>(h * scale));
+            auto* rz = static_cast<unsigned char*>(malloc(static_cast<size_t>(nw) * nh * 3));
+            if (!rz) { stbi_image_free(data); err = "out of memory"; return ""; }
+            stbir_resize_uint8(data, w, h, 0, rz, nw, nh, 0, 3);
+            stbi_image_free(data);
+            data = rz; w = nw; h = nh; resized = true;
+        }
+        std::vector<unsigned char> jpg;
+        auto cb = [](void* ctx, void* d, int s) {
+            auto* v = static_cast<std::vector<unsigned char>*>(ctx);
+            auto* b = static_cast<unsigned char*>(d);
+            v->insert(v->end(), b, b + s);
+        };
+        int ok = stbi_write_jpg_to_func(cb, &jpg, w, h, 3, data, jpeg_quality);
+        if (resized) free(data); else stbi_image_free(data);
+        if (!ok || jpg.empty()) { err = "JPEG encode failed"; return ""; }
+        return utils::base64_encode(jpg.data(), jpg.size());
     };
 
     json content = json::array();
     std::vector<std::string> skipped;
     for (const auto& out : selected) {
-        std::string mime = mime_for(out);
-        if (mime.empty()) {
-            skipped.push_back(out + " (unsupported type for inline content)");
-            continue;
-        }
         std::string full_path = queue_manager_.output_dir() + "/" + out;
-        std::ifstream f(full_path, std::ios::binary);
-        if (!f) {
-            skipped.push_back(out + " (file not found on disk)");
+        std::string err;
+        std::string b64 = encode_jpeg(full_path, err);
+        if (b64.empty()) {
+            skipped.push_back(out + " (" + err + ")");
             continue;
         }
-        std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(f)),
-                                   std::istreambuf_iterator<char>());
         content.push_back({
             {"type", "image"},
-            {"data", utils::base64_encode(bytes)},
-            {"mimeType", mime}
+            {"data", b64},
+            {"mimeType", "image/jpeg"}
         });
     }
 

--- a/src/mcp_server.cpp
+++ b/src/mcp_server.cpp
@@ -3,11 +3,16 @@
 #include "queue_manager.hpp"
 #include "memory_utils.hpp"
 #include "auth_manager.hpp"
+#include "utils.hpp"
 
 #include <iostream>
 #include <fstream>
 #include <optional>
 #include <set>
+#include <vector>
+#include <iterator>
+#include <cctype>
+#include <cstdint>
 
 namespace sdcpp {
 
@@ -317,6 +322,20 @@ json McpServer::handle_list_tools() {
         }}
     });
 
+    // 4. image — fetch generated image bytes for a completed job
+    tools.push_back({
+        {"name", "image"},
+        {"description", "Fetch the actual generated image(s) for a completed job as inline image content (not just a URL). Use this after 'generate' + 'job status' to let the model see the result. Returns image content blocks the model can view. Video (.mp4) outputs cannot be returned inline — use the URL from 'job status' instead."},
+        {"inputSchema", {
+            {"type", "object"},
+            {"required", json::array({"job_id"})},
+            {"properties", {
+                {"job_id", {{"type", "string"}, {"description", "Job UUID of a completed generation job"}}},
+                {"index", {{"type", "integer"}, {"description", "Zero-based index of a single output to fetch. Omit to fetch all outputs (capped at 4)."}}}
+            }}
+        }}
+    });
+
     return {{"tools", tools}};
 }
 
@@ -333,6 +352,7 @@ json McpServer::handle_call_tool(const json& params) {
     if (name == "generate") return tool_generate(args);
     if (name == "model") return tool_model(args);
     if (name == "job") return tool_job(args);
+    if (name == "image") return tool_image(args);
 
     return make_tool_result("Unknown tool: " + name, true);
 }
@@ -402,6 +422,102 @@ json McpServer::tool_generate(const json& args) {
     } catch (const std::exception& e) {
         return make_tool_result("Failed to queue job: " + std::string(e.what()), true);
     }
+}
+
+json McpServer::tool_image(const json& args) {
+    if (!args.contains("job_id") || !args["job_id"].is_string()) {
+        return make_tool_result("Missing required parameter: job_id", true);
+    }
+    std::string job_id = args["job_id"].get<std::string>();
+
+    auto job = queue_manager_.get_job(job_id);
+    if (!job.has_value()) {
+        return make_tool_result("Job not found: " + job_id, true);
+    }
+    if (job->outputs.empty()) {
+        return make_tool_result("Job has no outputs yet (status: " +
+            queue_status_to_string(job->status) + "). Wait for completion.", true);
+    }
+
+    // Resolve which outputs to fetch: a single one if 'index' given, else all.
+    std::vector<std::string> selected;
+    if (args.contains("index") && args["index"].is_number_integer()) {
+        long idx = args["index"].get<long>();
+        if (idx < 0 || static_cast<size_t>(idx) >= job->outputs.size()) {
+            return make_tool_result("index out of range: job has " +
+                std::to_string(job->outputs.size()) + " output(s)", true);
+        }
+        selected.push_back(job->outputs[static_cast<size_t>(idx)]);
+    } else {
+        selected = job->outputs;
+    }
+
+    // Cap inline payload to avoid blowing up the context with many large images.
+    constexpr size_t kMaxImages = 4;
+    bool truncated = selected.size() > kMaxImages;
+    if (truncated) selected.resize(kMaxImages);
+
+    // Map file extension to MIME type. Only raster image types are returnable
+    // as MCP image content; video (.mp4) and unknown types are skipped.
+    auto mime_for = [](const std::string& path) -> std::string {
+        auto dot = path.find_last_of('.');
+        if (dot == std::string::npos) return "";
+        std::string ext = path.substr(dot + 1);
+        for (auto& c : ext) c = static_cast<char>(::tolower(c));
+        if (ext == "png") return "image/png";
+        if (ext == "jpg" || ext == "jpeg") return "image/jpeg";
+        if (ext == "webp") return "image/webp";
+        if (ext == "gif") return "image/gif";
+        return "";
+    };
+
+    json content = json::array();
+    std::vector<std::string> skipped;
+    for (const auto& out : selected) {
+        std::string mime = mime_for(out);
+        if (mime.empty()) {
+            skipped.push_back(out + " (unsupported type for inline content)");
+            continue;
+        }
+        std::string full_path = queue_manager_.output_dir() + "/" + out;
+        std::ifstream f(full_path, std::ios::binary);
+        if (!f) {
+            skipped.push_back(out + " (file not found on disk)");
+            continue;
+        }
+        std::vector<uint8_t> bytes((std::istreambuf_iterator<char>(f)),
+                                   std::istreambuf_iterator<char>());
+        content.push_back({
+            {"type", "image"},
+            {"data", utils::base64_encode(bytes)},
+            {"mimeType", mime}
+        });
+    }
+
+    if (content.empty()) {
+        std::string msg = "No inline-returnable images for job " + job_id + ".";
+        if (!skipped.empty()) {
+            msg += " Skipped:";
+            for (const auto& s : skipped) msg += " " + s + ";";
+        }
+        return make_tool_result(msg, true);
+    }
+
+    // Prepend a short text note when some outputs were skipped or truncated so
+    // the model knows the inline images aren't the complete set.
+    if (truncated || !skipped.empty()) {
+        std::string note = "Returning " + std::to_string(content.size()) +
+            " image(s) for job " + job_id + ".";
+        if (truncated) note += " Output list truncated to first " +
+            std::to_string(kMaxImages) + "; fetch others by 'index'.";
+        if (!skipped.empty()) {
+            note += " Skipped:";
+            for (const auto& s : skipped) note += " " + s + ";";
+        }
+        content.insert(content.begin(), {{"type", "text"}, {"text", note}});
+    }
+
+    return {{"content", content}};
 }
 
 json McpServer::tool_model(const json& args) {

--- a/src/request_handlers.cpp
+++ b/src/request_handlers.cpp
@@ -174,6 +174,7 @@ RequestHandlers::RequestHandlers(ModelManager& model_manager, QueueManager& queu
       paths_config_(config.paths),
       allow_public_outputs_(config.auth.allow_public_outputs),
       trusted_proxies_(config.server.trusted_proxies),
+      mcp_image_tool_enabled_(config.mcp.image_tool_enabled),
       output_dir_(output_dir), webui_dir_(webui_dir), docs_dir_(docs_dir)
     // ArchitectureManager uses config directory (where model_architectures.json lives), not output directory
     , architecture_manager_(std::make_unique<ArchitectureManager>(
@@ -1064,6 +1065,9 @@ void RequestHandlers::handle_health(const httplib::Request& req, httplib::Respon
             // bundles that gate UI on it; can be dropped after a release or
             // two.
             {"sefi_image", true},
+            // Runtime config toggle (not a build flag): whether the MCP `image`
+            // tool that returns generated images inline is enabled.
+            {"mcp_image_tool", mcp_image_tool_enabled_},
             {"auth_required", auth_manager_.enabled()}
         }}
     };


### PR DESCRIPTION
## What

Adds a fourth MCP tool, `image(job_id, [index])`, that returns a completed job's output image(s) as **inline MCP image content** (base64 + `mimeType`) instead of just a URL.

## Why

The MCP `generate` flow previously only exposed output file **URLs** (via `job status` / the `sdcpp://queue` resource). An AI client could link to the result but could not actually *see* it. This tool returns the bytes inline so the model can view what it generated and iterate.

## How

- **`QueueManager::output_dir()`** — new getter exposing the output directory so callers can resolve the on-disk path for a job's relative output entries.
- **`tool_image`**:
  - Looks up the job; errors if not found or if it has no outputs yet (reports current status).
  - `index` selects a single output; omitted = all outputs, capped at **4** to bound payload size.
  - Maps file extension → MIME: `png`, `jpg`/`jpeg`, `webp`, `gif`.
  - Skips `.mp4` and unknown types (MCP has no inline video content) — use the URL from `job status` for those.
  - Prepends a short text note when outputs are truncated or skipped, so the model knows the inline set is incomplete.

## Usage flow

`generate` → `job status` (get `job_id`) → `image(job_id)` to view the result.

## Reviewer notes

- New tool only; existing tools unchanged.
- Not yet compiled here (full build pulls/compiles the sd.cpp dep). Worth a local `cmake` build before merge.
- `image` content blocks reuse the existing `utils::base64_encode`, same pattern as `request_handlers.cpp`.

## Files

- `include/queue_manager.hpp` — `output_dir()` getter
- `include/mcp_server.hpp` — `tool_image` declaration
- `src/mcp_server.cpp` — tool definition, dispatch, implementation, includes
- `CLAUDE.md` — MCP tools doc (3 → 4)

## Example
<img width="774" height="813" alt="Screenshot 2026-06-25 at 20 08 16" src="https://github.com/user-attachments/assets/e49e94f6-68b6-4f77-9459-3bf3190bb76a" />
